### PR TITLE
Initialize GradCAM mask summation with zeros.

### DIFF
--- a/grad-cam.py
+++ b/grad-cam.py
@@ -103,7 +103,7 @@ def grad_cam(input_model, image, category_index, layer_name):
     output, grads_val = output[0, :], grads_val[0, :, :, :]
 
     weights = np.mean(grads_val, axis = (0, 1))
-    cam = np.ones(output.shape[0 : 2], dtype = np.float32)
+    cam = np.zeros(output.shape[0 : 2], dtype = np.float32)
 
     for i, w in enumerate(weights):
         cam += w * output[:, :, i]


### PR DESCRIPTION
From my read of the GradCAM paper, this matrix should be initialized with zeroes, so that cam contains only the weighted sum of the entries in outputs. Feel free to correct me here if I'm misinterpreting anything!

[This doesn't affect the qualitative trend you see across the image in any of the generated GradCAM masks, since this is a constant shift at each pixel, but it does slightly perturb some of the numeric values.]